### PR TITLE
README: modify the build step for binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+capdctl
+capd-manager
+kind-test

--- a/README.md
+++ b/README.md
@@ -6,10 +6,16 @@ A sample is built and hosted at `gcr.io/kubernetes1-226021/capd-manager:latest`
 
 ### Building the binaries
 
-Requires go with go modules.
+Requires go 1.12+ with go modules.
 
-* `go build ./cmd/...`
-* `go build ./cmd/`
+```
+# required if `cluster-api-provider-docker` was cloned into $GOPATH
+export GO111MODULE=on
+# build the binaries
+go build ./cmd/capdctl
+go build ./cmd/capd-manager
+go build ./cmd/kind-test
+```
 
 ### Building the image
 


### PR DESCRIPTION
'-o' for directories is still bleeding edge and has some bugs in 1.12.
See issue 14295 in https://github.com/golang/go.

- Inline separate build commands for the binaries.
- Include GO111MODULE=on as it's still required.
- Include the binaries in .gitignore

fixes #9

/priority backlog
/kind documentation
/assign @chuckha 
