### PR TITLE
go-modules: fix build, module name and local imports

### DIFF
--- a/actuators/actuators.go
+++ b/actuators/actuators.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/chuckha/cluster-api-provider-docker/kind/actions"
+	"github.com/kubernetes-sigs/cluster-api-provider-docker/kind/actions"
 	"github.com/pkg/errors"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	"sigs.k8s.io/kind/pkg/cluster/constants"

--- a/actuators/machine.go
+++ b/actuators/machine.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/chuckha/cluster-api-provider-docker/kind/actions"
+	"github.com/kubernetes-sigs/cluster-api-provider-docker/kind/actions"
 	apicorev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"

--- a/cmd/capd-manager/main.go
+++ b/cmd/capd-manager/main.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/chuckha/cluster-api-provider-docker/actuators"
+	"github.com/kubernetes-sigs/cluster-api-provider-docker/actuators"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/cluster-api/pkg/apis"
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/common"

--- a/cmd/capdctl/main.go
+++ b/cmd/capdctl/main.go
@@ -23,7 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/chuckha/cluster-api-provider-docker/execer"
+	"github.com/kubernetes-sigs/cluster-api-provider-docker/execer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
@@ -117,7 +117,7 @@ subcommands are:
     example: capdctl capd -capd-image gcr.io/kubernetes1-226021/capd-manager:latest -capi-image gcr.io/k8s-cluster-api/cluster-api-controller:0.1.2 | kubeclt apply -f -
 
   control-plane - Write a capd control plane machine to stdout
-    example: capdctl control-plane -name my-control-plane -namespace my-namespace -cluster-name my-cluster -version v1.14.1 | kubectl apply -f - 
+    example: capdctl control-plane -name my-control-plane -namespace my-namespace -cluster-name my-cluster -version v1.14.1 | kubectl apply -f -
 
   worker - Write a capd worker machine to stdout
     example: capdctl worker -name my-worker -namespace my-namespace -cluster-name my-cluster -version 1.14.2 | kubectl apply -f -

--- a/cmd/kind-test/main.go
+++ b/cmd/kind-test/main.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/chuckha/cluster-api-provider-docker/kind/actions"
+	"github.com/kubernetes-sigs/cluster-api-provider-docker/kind/actions"
 	"sigs.k8s.io/kind/pkg/cluster/constants"
 	"sigs.k8s.io/kind/pkg/cluster/nodes"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/chuckha/cluster-api-provider-docker
+module github.com/kubernetes-sigs/cluster-api-provider-docker
 
 go 1.12
 

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30/go.mod h1:4AJxU
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
-github.com/chuckha/kind v0.0.0-20190609180745-73d145437758 h1:8GCRyfBf8Yvfq0GEgm6+eTy4pzlm6q8OX0V3dphg4BM=
-github.com/chuckha/kind v0.0.0-20190609180745-73d145437758/go.mod h1:HGXCFSnupsoKutuhd4/jdMbbthVU2IxeLWWh0qKr9K8=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/kind/actions/cluster_actions.go
+++ b/kind/actions/cluster_actions.go
@@ -22,8 +22,8 @@ import (
 	"html/template"
 	"strings"
 
-	"github.com/chuckha/cluster-api-provider-docker/kind/kubeadm"
-	"github.com/chuckha/cluster-api-provider-docker/third_party/forked/loadbalancer"
+	"github.com/kubernetes-sigs/cluster-api-provider-docker/kind/kubeadm"
+	"github.com/kubernetes-sigs/cluster-api-provider-docker/third_party/forked/loadbalancer"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/kind/pkg/cluster/constants"
 	"sigs.k8s.io/kind/pkg/cluster/nodes"

--- a/kind/actions/kind.go
+++ b/kind/actions/kind.go
@@ -27,7 +27,7 @@ import (
 
 	"sigs.k8s.io/kind/pkg/cluster/config/defaults"
 
-	"github.com/chuckha/cluster-api-provider-docker/third_party/forked/loadbalancer"
+	"github.com/kubernetes-sigs/cluster-api-provider-docker/third_party/forked/loadbalancer"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/kind/pkg/cluster/constants"
 	"sigs.k8s.io/kind/pkg/cluster/nodes"


### PR DESCRIPTION
fix the build in current master:

- update module to github.com/kubernetes-sigs/cluster-api-provider-docker
- modify github.com/chuckha/cluster-api-provider-docker imports to
github.com/kubernetes-sigs/cluster-api-provider-docker/kind/actions
run 'go mod tidy'
- rename DeleteClusterNode to DeleteNode
the existing functions don't have Cluster in the name:
DeleteControlPlane, DeleteWorker

/kind bug
/priority backlog
/assign @chuckha 
