### PR TITLE
Add logger to actuators

### DIFF
--- a/actuators/cluster.go
+++ b/actuators/cluster.go
@@ -17,39 +17,34 @@ limitations under the License.
 package actuators
 
 import (
-	"fmt"
-
+	"github.com/go-logr/logr"
 	"sigs.k8s.io/cluster-api-provider-docker/kind/actions"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
 // Cluster defines a cluster actuator object
 type Cluster struct {
-}
-
-// NewClusterActuator returns a new cluster actuator object
-func NewClusterActuator() *Cluster {
-	return &Cluster{}
+	Log logr.Logger
 }
 
 // Reconcile setups an external load balancer for the cluster if needed
 func (c *Cluster) Reconcile(cluster *clusterv1.Cluster) error {
 	elb, err := getExternalLoadBalancerNode(cluster.Name)
 	if err != nil {
-		fmt.Printf("%+v\n", err)
+		c.Log.Error(err, "Error getting external load balancer node")
 		return err
 	}
 	if elb != nil {
-		fmt.Println("External Load Balancer already exists. Nothing to do for this cluster.")
+		c.Log.Info("External Load Balancer already exists. Nothing to do for this cluster.")
 		return nil
 	}
-	fmt.Printf("The cluster named %q has been created! Setting up some infrastructure.\n", cluster.Name)
+	c.Log.Info("Cluster has been created! Setting up some infrastructure", "cluster-name", cluster.Name)
 	_, err = actions.SetUpLoadBalancer(cluster.Name)
 	return err
 }
 
 // Delete can be used to delete a cluster
 func (c *Cluster) Delete(cluster *clusterv1.Cluster) error {
-	fmt.Println("Cluster delete is not implemented.")
+	c.Log.Info("Cluster delete is not implemented.")
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30 // indirect
-	github.com/go-logr/logr v0.1.0 // indirect
+	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1 // indirect
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
 	github.com/google/btree v1.0.0 // indirect
@@ -25,6 +25,7 @@ require (
 	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d
 	k8s.io/client-go v11.0.0+incompatible
 	k8s.io/cluster-bootstrap v0.0.0-20181213155137-5f9271efc2e7 // indirect
+	k8s.io/klog v0.3.0
 	k8s.io/kubernetes v1.13.1
 	sigs.k8s.io/cluster-api v0.0.0-20190607141803-aacb0c613ffb
 	sigs.k8s.io/controller-runtime v0.1.10

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logger
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+)
+
+// Log is a wrapper to add a stacktrace to the Error message
+type Log struct {
+	logr.Logger
+}
+
+func (k Log) Error(err error, msg string, keysAndValues ...interface{}) {
+	k.Logger.Error(err, msg, "stacktrace", fmt.Sprintf("%+v", err), keysAndValues)
+}


### PR DESCRIPTION
This PR partially addresses: https://github.com/kubernetes-sigs/cluster-api-provider-docker/issues/22
Specifically this adds loggers to the actuators. 

The pattern used here was inspired by the aws provider. Ex: https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/master/pkg/cloud/aws/actuators/cluster/actuator.go#L41