### PR TITLE
Fix up the secret name

### DIFF
--- a/actuators/actuators.go
+++ b/actuators/actuators.go
@@ -70,7 +70,8 @@ func kubeconfigToSecret(clusterName, namespace string) (*v1.Secret, error) {
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
-			"kubeconfig": data,
+			// TODO pull in constant from cluster api
+			"value": data,
 		},
 	}, nil
 }


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

closes #42 

This aligns with the assumption cluster api v0.1.4 makes with regard to the name of the kubeconfigs secret.

/cc @amy 