### PR TITLE
Cluster reconciliation should reconcile exited ELB

### DIFF
--- a/actuators/actuators.go
+++ b/actuators/actuators.go
@@ -29,6 +29,10 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster/nodes"
 )
 
+const (
+	containerRunningStatus = "running"
+)
+
 func getRole(machine *clusterv1.Machine) string {
 	// Figure out what kind of node we're making
 	labels := machine.GetLabels()
@@ -40,9 +44,11 @@ func getRole(machine *clusterv1.Machine) string {
 }
 
 func getExternalLoadBalancerNode(clusterName string) (*nodes.Node, error) {
+	fmt.Printf("Getting external load balancer node for cluster %q\n", clusterName)
 	elb, err := nodes.List(
 		fmt.Sprintf("label=%s=%s", constants.NodeRoleKey, constants.ExternalLoadBalancerNodeRoleValue),
 		fmt.Sprintf("label=%s=%s", constants.ClusterLabelKey, clusterName),
+		fmt.Sprintf("status=%s", containerRunningStatus),
 	)
 	if err != nil {
 		return nil, err
@@ -53,6 +59,7 @@ func getExternalLoadBalancerNode(clusterName string) (*nodes.Node, error) {
 	if len(elb) > 1 {
 		return nil, errors.New("too many external load balancers")
 	}
+	fmt.Printf("External loadbalancer node for cluster %q is %v\n", clusterName, elb[0])
 	return &elb[0], nil
 }
 

--- a/actuators/actuators.go
+++ b/actuators/actuators.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,8 +44,8 @@ func getRole(machine *clusterv1.Machine) string {
 	return setValue
 }
 
-func getExternalLoadBalancerNode(clusterName string) (*nodes.Node, error) {
-	fmt.Printf("Getting external load balancer node for cluster %q\n", clusterName)
+func getExternalLoadBalancerNode(clusterName string, log logr.Logger) (*nodes.Node, error) {
+	log.Info("Getting external load balancer node for cluster", "cluster-name", clusterName)
 	elb, err := nodes.List(
 		fmt.Sprintf("label=%s=%s", constants.NodeRoleKey, constants.ExternalLoadBalancerNodeRoleValue),
 		fmt.Sprintf("label=%s=%s", constants.ClusterLabelKey, clusterName),
@@ -59,7 +60,7 @@ func getExternalLoadBalancerNode(clusterName string) (*nodes.Node, error) {
 	if len(elb) > 1 {
 		return nil, errors.New("too many external load balancers")
 	}
-	fmt.Printf("External loadbalancer node for cluster %q is %v\n", clusterName, elb[0])
+	log.Info("External loadbalancer node for cluster", "cluster-name", clusterName, "elb", elb[0])
 	return &elb[0], nil
 }
 

--- a/actuators/cluster.go
+++ b/actuators/cluster.go
@@ -29,6 +29,7 @@ type Cluster struct {
 
 // Reconcile setups an external load balancer for the cluster if needed
 func (c *Cluster) Reconcile(cluster *clusterv1.Cluster) error {
+	fmt.Printf("Reconciling cluster %s/%s\n", cluster.Namespace, cluster.Name)
 	elb, err := getExternalLoadBalancerNode(cluster.Name)
 	if err != nil {
 		c.Log.Error(err, "Error getting external load balancer node")

--- a/actuators/cluster.go
+++ b/actuators/cluster.go
@@ -29,8 +29,8 @@ type Cluster struct {
 
 // Reconcile setups an external load balancer for the cluster if needed
 func (c *Cluster) Reconcile(cluster *clusterv1.Cluster) error {
-	fmt.Printf("Reconciling cluster %s/%s\n", cluster.Namespace, cluster.Name)
-	elb, err := getExternalLoadBalancerNode(cluster.Name)
+	c.Log.Info("Reconciling cluster", "cluster-namespace", cluster.Namespace, "cluster-name", cluster.Name)
+	elb, err := getExternalLoadBalancerNode(cluster.Name, c.Log)
 	if err != nil {
 		c.Log.Error(err, "Error getting external load balancer node")
 		return err

--- a/actuators/machine.go
+++ b/actuators/machine.go
@@ -92,7 +92,7 @@ func (m *Machine) Create(ctx context.Context, c *clusterv1.Cluster, machine *clu
 		}
 
 		m.Log.Info("Creating a brand new cluster")
-		elb, err := getExternalLoadBalancerNode(c.Name)
+		elb, err := getExternalLoadBalancerNode(c.Name, m.Log)
 		if err != nil {
 			m.Log.Error(err, "Error getting external load balancer node")
 			return err


### PR DESCRIPTION
* get only running ELB containers
* remove exited ELB containers with name conflict

Signed-off-by: Ashish Amarnath <ashish.amarnath@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Cluster reconciliation should reconcile deleted ELBs

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #52 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
