### PR TITLE
Be flexible with versions

### DIFF
--- a/cmd/capdctl/main.go
+++ b/cmd/capdctl/main.go
@@ -265,7 +265,7 @@ func makeManagementCluster(clusterName, capiVersion, capdImage, capiImageOverrid
 			HostPath:      "/var/run/docker.sock",
 		},
 	}
-	cp, err := actions.CreateControlPlane(clusterName, "management-control-plane", lbipv4, "v1.14.2", cpMounts)
+	cp, err := actions.CreateControlPlane(clusterName, fmt.Sprintf("%s-control-plane", clusterName), lbipv4, "v1.14.2", cpMounts)
 	if err != nil {
 		panic(err)
 	}
@@ -293,6 +293,8 @@ func makeManagementCluster(clusterName, capiVersion, capdImage, capiImageOverrid
 	cmd.SetStdout(os.Stdout)
 	cmd.SetStderr(os.Stderr)
 	if err := cmd.Run(); err != nil {
+		out, _ := ioutil.ReadFile(f.Name())
+		fmt.Println(out)
 		panic(err)
 	}
 }

--- a/kind/actions/kind.go
+++ b/kind/actions/kind.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api-provider-docker/third_party/forked/loadbalancer"
@@ -291,6 +292,9 @@ func writeKubeConfig(n *nodes.Node, dest string, hostAddress string, hostPort in
 }
 
 func image(version string) string {
+	if !strings.HasPrefix(version, "v") {
+		version = fmt.Sprintf("v%s", version)
+	}
 	// valid kindest node versions, but only > v1.14.0
 	switch version {
 	case "v1.14.1", "v1.14.2", "v1.14.3", "v1.15.0":


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
We should be flexible with version numbers. v1.14.1? 1.14.1? whatever, it's all good

There is also a minor fix to be able to rename the management cluster.

```release-note
NONE
```