### PR TITLE
make 6443 as a constant

### DIFF
--- a/kind/actions/cluster_actions.go
+++ b/kind/actions/cluster_actions.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pkg/errors"
 	k8sversion "k8s.io/apimachinery/pkg/util/version"
+	constkind "sigs.k8s.io/cluster-api-provider-docker/kind/constants"
 	"sigs.k8s.io/cluster-api-provider-docker/kind/kubeadm"
 	"sigs.k8s.io/cluster-api-provider-docker/third_party/forked/loadbalancer"
 	"sigs.k8s.io/kind/pkg/cluster/constants"
@@ -99,7 +100,7 @@ func ConfigureLoadBalancer(clusterName string) error {
 		if err != nil {
 			return errors.Wrapf(err, "failed to get IP for node %s", n.Name())
 		}
-		backendServers[n.Name()] = fmt.Sprintf("%s:%d", controlPlaneIPv4, 6443)
+		backendServers[n.Name()] = fmt.Sprintf("%s:%d", controlPlaneIPv4, constkind.APIServerPort)
 	}
 
 	// create loadbalancer config data
@@ -126,7 +127,8 @@ func KubeadmConfig(node *nodes.Node, clusterName, lbip string) error {
 		return errors.Wrap(err, "failed to get kubernetes version from node")
 	}
 
-	kubeadmConfig, err := kubeadm.InitConfiguration(kubeVersion, clusterName, fmt.Sprintf("%s:%d", lbip, 6443))
+	kubeadmConfig, err := kubeadm.InitConfiguration(kubeVersion, clusterName,
+		fmt.Sprintf("%s:%d", lbip, constkind.APIServerPort))
 
 	if err != nil {
 		return errors.Wrap(err, "failed to generate kubeadm config content")

--- a/kind/actions/kind.go
+++ b/kind/actions/kind.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	constkind "sigs.k8s.io/cluster-api-provider-docker/kind/constants"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -247,7 +248,7 @@ func GetLoadBalancerHostAndPort(allNodes []nodes.Node) (string, int32, error) {
 	if err != nil {
 		return "", 0, err
 	}
-	port, err := node.Ports(6443)
+	port, err := node.Ports(constkind.APIServerPort)
 	return ipv4, port, err
 }
 

--- a/kind/actions/kind.go
+++ b/kind/actions/kind.go
@@ -24,10 +24,10 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	constkind "sigs.k8s.io/cluster-api-provider-docker/kind/constants"
 	"strings"
 
 	"github.com/pkg/errors"
+	constkind "sigs.k8s.io/cluster-api-provider-docker/kind/constants"
 	"sigs.k8s.io/cluster-api-provider-docker/third_party/forked/loadbalancer"
 	"sigs.k8s.io/kind/pkg/cluster/config/defaults"
 	"sigs.k8s.io/kind/pkg/cluster/constants"

--- a/kind/constants/constants.go
+++ b/kind/constants/constants.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+// APIServerPort is the expected default APIServerPort on the control plane node(s)
+// https://kubernetes.io/docs/reference/access-authn-authz/controlling-access/#api-server-ports-and-ips
+const APIServerPort = 6443

--- a/kind/kubeadm/config.go
+++ b/kind/kubeadm/config.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeadmv1beta1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta1"
 	"k8s.io/kubernetes/pkg/kubelet/apis/config"
+	"sigs.k8s.io/cluster-api-provider-docker/kind/constants"
 )
 
 const (
@@ -52,7 +53,7 @@ func InitConfiguration(version, name, controlPlaneEndpoint string) ([]byte, erro
 			},
 		},
 		LocalAPIEndpoint: kubeadmv1beta1.APIEndpoint{
-			BindPort: int32(6443),
+			BindPort: int32(constants.APIServerPort),
 		},
 		NodeRegistration: kubeadmv1beta1.NodeRegistrationOptions{
 			CRISocket: "/run/containerd/containerd.sock",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:We hardcode 6443 all over the place and it should be a constant

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #66 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
