### PR TITLE
use the github master as the default image

### DIFF
--- a/cmd/capdctl/main.go
+++ b/cmd/capdctl/main.go
@@ -64,7 +64,7 @@ func main() {
 	setup := flag.NewFlagSet("setup", flag.ExitOnError)
 	managementClusterName := setup.String("cluster-name", "management", "The name of the management cluster")
 	version := setup.String("capi-version", "v0.1.7", "The CRD versions to pull from CAPI. Does not support < v0.1.7.")
-	capdImage := setup.String("capd-image", "gcr.io/kubernetes1-226021/capd-manager:latest", "The capd manager image to run")
+	capdImage := setup.String("capd-image", "docker.pkg.github.com/kubernetes-sigs/cluster-api-provider-docker/manager:master", "The capd manager image to run")
 	capiImage := setup.String("capi-image", "", "This is normally left blank and filled in automatically. But this will override the generated image name.")
 
 	controlPlane := flag.NewFlagSet("control-plane", flag.ExitOnError)


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR uses the default image of capd to be the default GitHub latest image built off HEAD. we should change this to a release version when we release a version.

```release-note
NONE
```