### PR TITLE
Attempt to push the images after running goreleaser

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -25,3 +25,9 @@ action "goreleaser" {
   args = "release"
   needs = ["is-tag", "Setup Google Cloud", "Set Credential Helper for Docker"]
 }
+
+action "push images" {
+  uses = "actions/docker/cli@master"
+  args = "images --filter reference=gcr.io/kubernetes1-226021/capd-manager --format '{{.Repository}}:{{.Tag}}' | xargs -n1 docker push"
+  needs = ["goreleaser"]
+}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,6 +40,7 @@ snapshot:
 dockers:
   - goos: linux
     goarch: amd64
+    skip_push: true
     binaries:
     - capd-manager
     image_templates:


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
We cannot push from within the goreleaser docker image. It requires credentials it cannot get.

Try to push with the configured docker. This may work since docker sockets are shared. It may not work if the images don't exist on the external socket.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #67 

**Release note**:
```release-note
NONE
```

/assign @ashish-amarnath 
