### PR TITLE
revamp of tag and push workflow

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -23,11 +23,21 @@ action "goreleaser" {
   uses = "docker://goreleaser/goreleaser"
   secrets = ["GORELEASER_GITHUB_TOKEN"]
   args = "release"
-  needs = ["is-tag", "Setup Google Cloud", "Set Credential Helper for Docker"]
+  needs = ["is-tag"]
+}
+
+action "tag images" {
+  uses = "actions/docker/tag@master"
+  args = "capd-manager gcr.io/kubernetes1-226021/capd-manager"
+  needs = ["goreleaser"]
 }
 
 action "push images" {
   uses = "actions/docker/cli@master"
-  args = "images --filter reference=gcr.io/kubernetes1-226021/capd-manager --format '{{.Repository}}:{{.Tag}}' | xargs -n1 docker push"
-  needs = ["goreleaser"]
+  runs = "sh -c"
+  env = {
+    IMAGE_NAME = gcr.io/kubernetes1-226021/capd-manager
+  }
+  args = "source $HOME/.profile && docker push $IMAGE_NAME:latest && docker push $IMAGE_NAME:$IMAGE_REF && docker push $IMAGE_NAME:$IMAGE_SHA && docker push $IMAGE_NAME:$IMAGE_VERSION"
+  needs = ["tag images", "Set Credential Helper for Docker"]
 }

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,6 +44,4 @@ dockers:
     binaries:
     - capd-manager
     image_templates:
-    - "gcr.io/kubernetes1-226021/capd-manager:{{.Version}}"
-    - "gcr.io/kubernetes1-226021/capd-manager:{{.Major}}.{{.Minor}}"
-    - "gcr.io/kubernetes1-226021/capd-manager:latest"
+    - capd-manager


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>
Goreleaser will tag a base image
Then docker (outside of the goreleaser container) will tag the image goreleaser made with the right tags and then push using gcloud authentication.

**What this PR does / why we need it**:
we might not tbh

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #67 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note
NONE
```