### PR TITLE
Manual release of container images

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,11 +1,6 @@
 workflow "Release" {
   on = "push"
-  resolves = ["push images"]
-}
-
-action "Setup Google Cloud" {
-  uses = "actions/gcloud/auth@master"
-  secrets = ["GCLOUD_AUTH"]
+  resolves = ["goreleaser"]
 }
 
 action "is-tag" {
@@ -13,37 +8,9 @@ action "is-tag" {
   args = "tag"
 }
 
-action "Set Credential Helper for Docker" {
-  needs = ["Setup Google Cloud"]
-  uses = "actions/gcloud/cli@master"
-  args = ["auth", "configure-docker", "--quiet"]
-}
-
 action "goreleaser" {
   uses = "docker://goreleaser/goreleaser"
   secrets = ["GORELEASER_GITHUB_TOKEN"]
   args = "release"
   needs = ["is-tag"]
-}
-
-action "docker build" {
-  uses = "actions/docker/cli@master"
-  args = "build -t capd-manager ."
-  needs = ["goreleaser"]
-}
-
-action "tag images" {
-  uses = "actions/docker/tag@master"
-  args = "capd-manager gcr.io/kubernetes1-226021/capd-manager"
-  needs = ["docker build"]
-}
-
-action "push images" {
-  uses = "actions/docker/cli@master"
-  runs = "sh -c"
-  env = {
-    IMAGE_NAME = "gcr.io/kubernetes1-226021/capd-manager"
-  }
-  args = ["source $HOME/.profile && docker push $IMAGE_NAME:latest && docker push $IMAGE_NAME:$IMAGE_REF && docker push $IMAGE_NAME:$IMAGE_SHA && docker push $IMAGE_NAME:$IMAGE_VERSION"]
-  needs = ["tag images", "Set Credential Helper for Docker"]
 }

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,3 +37,17 @@ checksum:
   name_template: 'checksums.txt'
 snapshot:
   name_template: "{{ .Tag }}-next"
+dockers:
+  - goos: linux
+    goarch: amd64
+    skip_push: true
+    binaries:
+      - capd-manager
+    image_templates:
+      - "gcr.io/kubernetes1-226021/capd-manager:{{.Version}}"
+      - "gcr.io/kubernetes1-226021/capd-manager:{{.Major}}.{{.Minor}}"
+      - "gcr.io/kubernetes1-226021/capd-manager:latest"
+changelog:
+  filters:
+    exclude:
+      - '^Merge pull request'

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,30 @@
+# Creating a release
+
+Tag the repository with the version you want
+
+`git tag -a v0.1.2 -m 'a patch release'`
+
+then push the tag
+
+`git push origin refs/tags/v0.1.2`
+
+Github actions will take care of the rest.
+
+Please edit the generated change log.
+
+## Container Images
+
+Container images must be pushed from your local machine.
+
+### via Goreleaser
+
+If you have [goreleaser](https://goreleaser.com/) installed you can run
+`goreleaser --skip-publish` and push the generated images.
+
+### manually
+
+Manually build the Dockerfile using `docker build`. The tag pattern is:
+
+* `:latest` - This is the latest release
+* `:<major>.<minor>` - This is the latest minor release in the series
+* `:<major>.<minor>.<patch>` - This is the specific version


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds documentation for manually releasing the container images.

Enough time has been wasted gettin GitHub actions to work.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #67 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

/assign @detiber 

What do you think of this release process?