### PR TITLE
Rename capd-manager to manager

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,8 +44,8 @@ dockers:
     binaries:
       - capd-manager
     image_templates:
-      - "gcr.io/kubernetes1-226021/capd-manager:{{.Version}}"
-      - "gcr.io/kubernetes1-226021/capd-manager:{{.Major}}.{{.Minor}}"
+      - "gcr.io/kubernetes1-226021/capd-manager:{{.Tag}}"
+      - "gcr.io/kubernetes1-226021/capd-manager:v{{.Major}}.{{.Minor}}"
       - "gcr.io/kubernetes1-226021/capd-manager:latest"
 changelog:
   filters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ WORKDIR /tmp
 RUN curl -L https://dl.k8s.io/v1.14.4/kubernetes-client-linux-amd64.tar.gz | tar xvz
 RUN mv /tmp/kubernetes/client/bin/kubectl /usr/local/bin
 RUN curl https://get.docker.com | sh
-COPY dist/capd-manager_linux_amd64/capd-manager /usr/local/bin
+COPY capd-manager /usr/local/bin
 
 ENTRYPOINT ["capd-manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ WORKDIR /tmp
 RUN curl -L https://dl.k8s.io/v1.14.4/kubernetes-client-linux-amd64.tar.gz | tar xvz
 RUN mv /tmp/kubernetes/client/bin/kubectl /usr/local/bin
 RUN curl https://get.docker.com | sh
-COPY capd-manager /usr/local/bin
+COPY manager /usr/local/bin
 
-ENTRYPOINT ["capd-manager"]
+ENTRYPOINT ["manager"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Manager Container Image
 
-A sample is built and hosted at `gcr.io/kubernetes1-226021/capd-manager:latest`
+A sample is built and hosted at `gcr.io/kubernetes1-226021/manager:latest`
 
 ### External Dependencies
 

--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -110,7 +110,7 @@ fi
 
 # comment out for now
 #if [[ "${VERIFY_DOCKER_BUILD:-true}" == "true" ]]; then
-#  echo "[*] Verifying capd-manager docker image build..."
+#  echo "[*] Verifying manager docker image build..."
 #  out=$(hack/verify-docker-build.sh 2>&1)
 #  failure $? "verify-docker-build.sh" "${out}"
 #  cd "${REPO_PATH}"

--- a/hack/verify-docker-build.sh
+++ b/hack/verify-docker-build.sh
@@ -25,5 +25,5 @@ cd_root_path
 
 export GO111MODULE=on
 go mod download
-go build -o capd-manager ./cmd/capd-manager
-docker build --file Dockerfile -t capd-manager:pr-verify .
+go build -o manager ./cmd/manager
+docker build --file Dockerfile -t manager:pr-verify .

--- a/scripts/build-binaries.sh
+++ b/scripts/build-binaries.sh
@@ -25,8 +25,8 @@ readonly REPO_PATH=$(get_root_path)
 readonly CAPDCTL_BIN=${REPO_PATH}/bin/capdctl
 readonly CAPDCTL_SRC=${REPO_PATH}/cmd/capdctl
 
-readonly CAPDMGR_BIN=${REPO_PATH}/bin/capd-manager
-readonly CAPDMGR_SRC=${REPO_PATH}/cmd/capd-manager
+readonly CAPDMGR_BIN=${REPO_PATH}/bin/manager
+readonly CAPDMGR_SRC=${REPO_PATH}/cmd/manager
 
 readonly KIND_TEST_BIN=${REPO_PATH}/bin/kind-test
 readonly KIND_TEST_SRC=${REPO_PATH}/cmd/kind-test
@@ -40,7 +40,7 @@ LDFLAGS="-s -w \
 
 # build capdctl
 go build -ldflags "${LDFLAGS}" -o ${CAPDCTL_BIN} ${CAPDCTL_SRC}
-# build capd-manager
+# build manager
 go build -ldflags "${LDFLAGS}" -o ${CAPDMGR_BIN} ${CAPDMGR_SRC}
 # build kind-test
 go build -ldflags "${LDFLAGS}" -o ${KIND_TEST_BIN} ${KIND_TEST_SRC}

--- a/scripts/publish-manager.sh
+++ b/scripts/publish-manager.sh
@@ -18,7 +18,7 @@ readonly GCP_PROJECT=$(gcloud config get-value project)
 set -o errexit
 set -o xtrace
 
-readonly IMAGE_NAME="capd-manager"
+readonly IMAGE_NAME="manager"
 
 readonly GCR_REGISTRY="gcr.io/${GCP_PROJECT}"
 readonly TAG=${TAG:-dev}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR renames capd-manager to `manager` to align with kubebuilder's expected default.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #119 

```release-note
NONE
```