### PR TITLE
Break `capdctl setup` into `capdctl kind` and `capdctl platform`

### DIFF
--- a/kind/controlplane/create.go
+++ b/kind/controlplane/create.go
@@ -27,7 +27,7 @@ import (
 )
 
 // CreateKindCluster sets up a  KIND cluster and turns it into a CAPD control plane
-func CreateKindCluster(image, clusterName string) error {
+func CreateKindCluster(clusterName string) error {
 	lb, err := actions.SetUpLoadBalancer(clusterName)
 	if err != nil {
 		return errors.Wrap(err, "failed to create load balancer")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Sometimes you want to just want to set up a cluster or just create the containers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #118 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
adds two new `capdctl` commands: `kind` (which creates a new kind cluster suitable for use with capd) and `platform` (which prints the CRDs and controllers to stdout)
```
