### PR TITLE
Ignore invalid samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ capdctl
 capd-manager
 kind-test
 
+# invalid samples.
+config/samples
+
 # vscode
 .vscode
 

--- a/config/samples/infrastructure_v1alpha1_dockermachine.yaml
+++ b/config/samples/infrastructure_v1alpha1_dockermachine.yaml
@@ -1,7 +1,0 @@
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
-kind: DockerMachine
-metadata:
-  name: dockermachine-sample
-spec:
-  # Add fields here
-  foo: bar


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This is a follow up to #122.

It removes invalid samples which we can add back later if they become valid and we have a test proving they are valid.

/assign @detiber 