### PR TITLE
fixes errors seen in verify-govet

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -23,5 +23,7 @@ source "$(dirname "$0")/utils.sh"
 # cd to the root path
 cd_root_path
 
+GOPROXY=$(go env GOPROXY)
+export GOPROXY="${GOPROXY:-https://proxy.golang.org}"
 export GO111MODULE="on"
 go mod tidy


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes errors in go vet like:
```
verifying gomodules.xyz/jsonpatch/v2@v2.0.0: checksum mismatch
	downloaded: h1:lHNQverf0+Gm1TbSbVIDWVXOhZ2FpZopxRqpr2uIjs4=
	go.sum:     h1:OyHbl+7IOECpPKfVK42oFr6N7+Y2dR+Jsb/IiDV3hOo=
```
This will help the tests pass for PR #148 