### PR TITLE
Add a MacOS step in the getting started secton of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Alternatively, run: `REGISTRY=<MY_REGISTRY> ./scripts/publish-manager.sh`
 
 ## Trying CAPD
 
-Tested on: Linux, works ok on OS X sometimes
+Tested on Linux and MacOS with [v0.1.3](https://github.com/kubernetes-sigs/cluster-api-provider-docker/releases/tag/v0.1.3).
 
 Make sure you have `kubectl`.
 
@@ -62,6 +62,9 @@ Make sure you have `kubectl`.
 The kubeconfig is on the management cluster in secrets. Grab it and write it to a file:
 
 `kubectl get secrets -o jsonpath='{.data.value}' my-cluster-kubeconfig | base64 --decode > ~/.kube/kind-config-my-cluster`
+
+On **MacOS**, you need to manually update the server address in the kubeconfig to point to the cluster load-balancer:
+`sed -i -e "s/server:.*/server: https:\/\/$(docker port my-cluster-external-load-balancer 6443 | sed "s/0.0.0.0/127.0.0.1/")/g" ~/.kube/kind-config-my-cluster`
 
 Look at the pods in your new worker cluster:
 `kubectl get po --all-namespaces --kubeconfig ~/.kube/kind-config-my-cluster`

--- a/examples/simple-cluster.yaml
+++ b/examples/simple-cluster.yaml
@@ -21,6 +21,7 @@ spec:
   providerSpec: {}
   versions:
     controlPlane: "v1.14.2"
+    kubelet: "v1.14.2"
 ---
 apiVersion: "cluster.k8s.io/v1alpha1"
 kind: Machine


### PR DESCRIPTION
As noted in the README, and mentioned in the last community meeting, due to the Docker VM host on MacOS, the kubeconfig stored in the secrets cannot directly be used by the user.

This PR addresses this issue for now, by introducing a temporary workaround in the form of a manual step, in which the faulty server address is replaced by the correct server address.

Other changes:
- explicitly mention the version that actually works with the instructions.
- fix the invalid example definitions.