### PR TITLE
Set docker cluster as ready to allow CAPI to proceed

### DIFF
--- a/controllers/dockercluster_controller.go
+++ b/controllers/dockercluster_controller.go
@@ -20,10 +20,10 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	infrastructurev1alpha2 "sigs.k8s.io/cluster-api-provider-docker/api/v1alpha2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	infrastructurev1alpha2 "sigs.k8s.io/cluster-api-provider-docker/api/v1alpha2"
 )
 
 // DockerClusterReconciler reconciles a DockerCluster object
@@ -37,10 +37,45 @@ type DockerClusterReconciler struct {
 
 // Reconcile handles DockerCluster events
 func (r *DockerClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-	_ = context.Background()
-	_ = r.Log.WithValues("dockercluster", req.NamespacedName)
+	ctx := context.Background()
+	log := r.Log.WithValues("dockercluster", req.NamespacedName)
 
-	// your logic here
+	dockerCluster := &infrastructurev1alpha2.DockerCluster{}
+	if err := r.Client.Get(ctx, req.NamespacedName, dockerCluster); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		log.Error(err, "failed to get dockerMachine")
+		return ctrl.Result{}, err
+	}
+
+	if dockerCluster.Status.Ready {
+		return ctrl.Result{}, nil
+	}
+
+	// Store Config's state, pre-modifications, to allow patching
+	patchCluster := client.MergeFrom(dockerCluster.DeepCopy())
+
+	// modify dockerCluster here
+
+	// TODO actually do something before setting this ready
+	dockerCluster.Status.Ready = true
+
+	// TODO(ncdc): remove this once we've updated to a version of controller-runtime with
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/526.
+	gvk := dockerCluster.GroupVersionKind()
+	if err := r.Patch(ctx, dockerCluster, patchCluster); err != nil {
+		log.Error(err, "failed to update dockerCluster")
+		return ctrl.Result{}, err
+	}
+
+	// TODO(ncdc): remove this once we've updated to a version of controller-runtime with
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/526.
+	dockerCluster.SetGroupVersionKind(gvk)
+	if err := r.Status().Patch(ctx, dockerCluster, patchCluster); err != nil {
+		log.Error(err, "failed to update docker cluster status")
+		return ctrl.Result{}, err
+	}
 
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
CAPI won't proceed unless the cluster's infrastructure ref is marked as ready.

```release-note
NONE
```

This should be a help to @ashish-amarnath and anyone implementing #151 in the docker-machine

/cc @ashish-amarnath @amy 
/assign @ncdc 