### PR TITLE
Use v0.1 image (latest image from release-0.1 branch) instead of latest image

### DIFF
--- a/cmd/capdctl/main.go
+++ b/cmd/capdctl/main.go
@@ -73,7 +73,7 @@ type platformOptions struct {
 
 func (po *platformOptions) initFlags(fs *flag.FlagSet) {
 	po.capiVersion = fs.String("capi-version", "v0.1.8", "The CRD versions to pull from CAPI. Does not support < v0.1.8.")
-	po.capdImage = fs.String("capd-image", "gcr.io/kubernetes1-226021/capd-manager:latest", "The capd manager image to run")
+	po.capdImage = fs.String("capd-image", "gcr.io/kubernetes1-226021/capd-manager:v0.1", "The capd manager image to run")
 	po.capiImage = fs.String("capi-image", "", "This is normally left blank and filled in automatically. But this will override the generated image name.")
 }
 


### PR DESCRIPTION
/cc @chuckha 

**What this PR does / why we need it:**
capdctl build off the `release-0.1` branch should not default to the `latest` image of capd-manager, since that may be built off the `master` branch.