### PR TITLE
Add capdctl, capd-manager versions to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,6 +19,7 @@ about: Tell us about a problem you are experiencing
 
 **Environment:**
 
-- Cluster-api-provider-docker version: 
-- Kubernetes version: (use `kubectl version`): 
-- OS (e.g. from `/etc/os-release`): 
+- capdctl version (use `capdctl version`):
+- capd-manager version (use `kubectl -n docker-provider-system get pods/docker-provider-controller-manager-0 -ojsonpath='{.status.containerStatuses[0].image}{"\n"}{.status.containerStatuses[0].imageID}{"\n"}'`):
+- Kubernetes version (use `kubectl version`):
+- OS (e.g. from `/etc/os-release`):


### PR DESCRIPTION
**What this PR does / why we need it**:
Asks users to report both the capdctl and capd-manager version, and adds helpful commands to make those easy to report.

/cc @chuckha