### PR TITLE
docs: Create a compatible kind cluster, and troubleshoot an incompatible one

### DIFF
--- a/docs/kind.md
+++ b/docs/kind.md
@@ -1,0 +1,19 @@
+# Deploy CAPD to an existing kind cluster
+
+The CAPD controllers need access to docker storage and docker socket on the host. Typically, these are `/var/lib/docker` and `/var/run/docker.sock`, respectively. These locations must be propagated from the host to the kind node(s) where CAPD controllers run. By default, kind does not propagate them. To create a kind cluster that supports CAPD controllers, propagate these using `extraMounts`
+
+```
+cat > kind-cluster-with-extramounts.yaml <<EOF
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+nodes:
+  - role: control-plane
+    extraMounts:
+      - hostPath: /var/lib/docker
+        containerPath: /var/lib/docker
+      - hostPath: /var/run/docker.sock
+        containerPath: /var/run/docker.sock
+EOF
+kind create cluster --config kind-cluster-with-extramounts.yaml --name management-cluster
+```
+

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,25 @@
+# Troubleshooting
+
+## docker-provider-controller-manager-0 Pod stuck in ContainerCreating phase
+
+1. Check for any warnings or errors:
+
+```
+$ kubectl -n docker-provider-system describe pod docker-provider-controller-manager-0
+```
+
+Are you running CAPD controllers in a kind cluster not created by `capdctl`? Do you see `MountVolume.SetUp` warnings like these?
+```
+Name:               docker-provider-controller-manager-0
+Namespace:          docker-provider-system
+...
+Events:
+  Type     Reason       Age                From                                   Message
+  ----     ------       ----               ----                                   -------
+  Normal   Scheduled    52s                default-scheduler                      Successfully assigned docker-provider-system/docker-provider-controller-manager-0 to capi-bootstrap-control-plane
+  Warning  FailedMount  21s (x7 over 52s)  kubelet, capi-bootstrap-control-plane  MountVolume.SetUp failed for volume "dockerlib" : hostPath type check failed: /var/lib/docker is not a directory
+  Warning  FailedMount  21s (x7 over 52s)  kubelet, capi-bootstrap-control-plane  MountVolume.SetUp failed for volume "dockersock" : hostPath type check failed: /var/run/docker.sock is not a socket file
+```
+
+If yes, then follow [these instructions](kind.md) to create a kind cluster that supports CAPD controllers.
+


### PR DESCRIPTION
**What this PR does / why we need it:**
Documents how to create a compatible kind cluster without capdctl.

Cherry-pick of #170 from release-0.1 branch. 