### PR TITLE
fix: enable status endpoints

### DIFF
--- a/api/v1alpha2/dockercluster_types.go
+++ b/api/v1alpha2/dockercluster_types.go
@@ -49,6 +49,7 @@ type APIEndpoint struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // DockerCluster is the Schema for the dockerclusters API
 type DockerCluster struct {

--- a/api/v1alpha2/dockermachine_types.go
+++ b/api/v1alpha2/dockermachine_types.go
@@ -40,6 +40,7 @@ type DockerMachineStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // DockerMachine is the Schema for the dockermachines API
 type DockerMachine struct {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
@@ -11,6 +11,8 @@ spec:
     kind: DockerCluster
     plural: dockerclusters
   scope: ""
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: DockerCluster is the Schema for the dockerclusters API

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
@@ -11,6 +11,8 @@ spec:
     kind: DockerMachine
     plural: dockermachines
   scope: ""
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: DockerMachine is the Schema for the dockermachines API


### PR DESCRIPTION
Signed-off-by: Andrew Rudoi <arudoi@newrelic.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR adds the kubebuilder annotations for enabling the status endpoint. The status patches don't work without this being enabled, as far as I'm aware.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
