### PR TITLE
Fix to broken simple-cluster

### DIFF
--- a/examples/simple-cluster.yaml
+++ b/examples/simple-cluster.yaml
@@ -21,6 +21,7 @@ spec:
   providerSpec: {}
   versions:
     controlPlane: "v1.14.2"
+    kubelet: "v1.14.2"
 ---
 apiVersion: "cluster.k8s.io/v1alpha1"
 kind: Machine


### PR DESCRIPTION
Signed-off-by: Dan Finneran dan@thebsdbox.co.uk

Currently the supplied example will result in an error due to `spec.versions.kublet` missing from a machine configuration.

As shown below:

```
$ kubectl apply -f ./examples/simple-cluster.yaml
cluster.cluster.k8s.io/my-cluster unchanged
machine.cluster.k8s.io/worker unchanged
The Machine "my-control-plane" is invalid: []: Invalid value: map[string]interface {}{"apiVersion":"cluster.k8s.io/v1alpha1", "kind":"Machine", "metadata":map[string]interface {}{"annotations":map[string]interface {}{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"cluster.k8s.io/v1alpha1\",\"kind\":\"Machine\",\"metadata\":{\"annotations\":{},\"labels\":{\"cluster.k8s.io/cluster-name\":\"my-cluster\",\"set\":\"controlplane\"},\"name\":\"my-control-plane\",\"namespace\":\"default\"},\"spec\":{\"providerSpec\":{},\"versions\":{\"controlPlane\":\"v1.14.2\"}}}\n"}, "creationTimestamp":"2019-08-13T14:23:45Z", "generation":2, "labels":map[string]interface {}{"cluster.k8s.io/cluster-name":"my-cluster", "set":"controlplane"}, "name":"my-control-plane", "namespace":"default", "resourceVersion":"1113", "uid":"f5352c0c-bdd5-11e9-b8b1-0242ac110003"}, "spec":map[string]interface {}{"providerSpec":map[string]interface {}{}, "versions":map[string]interface {}{"controlPlane":"v1.14.2"}}}: validation failure list:
spec.versions.kubelet in body is required
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

The current example results in an error provisioning the various `machine` specs, this tiny pr adds the missing kubelet info required to deploy.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
