### PR TITLE
Insert --ignore-preflight-errors=all into kubeadm commands

### DIFF
--- a/cloudinit/rumcmd.go
+++ b/cloudinit/rumcmd.go
@@ -55,6 +55,9 @@ func (c *Cmd) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &s2); err != nil {
 		return errors.WithStack(err)
 	}
+	if strings.HasPrefix(s2, "kubeadm") {
+		s2 = strings.Replace(s2, "kubeadm", "kubeadm --ignore-preflight-errors=all", 1)
+	}
 	c.Cmd = "/bin/sh"
 	c.Args = []string{"-c", s2}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Inserts `--ignore-preflight-errors=all` into kubeadm commands

**Release note**:
```release-note
NONE
```
