### PR TITLE
🐛 Fix DockerMachine delete for first control plane

### DIFF
--- a/docker/actions/cluster_actions.go
+++ b/docker/actions/cluster_actions.go
@@ -169,6 +169,10 @@ func DeleteClusterNode(clusterName, nodeName string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to list all control planes")
 	}
+	// If there is only one control plane being deleted do not update the corev1.Node list
+	if len(allControlPlanes) == 1 {
+		return nil
+	}
 	var node nodes.Node
 	// pick one that doesn't match the node name we are trying to delete
 	for _, n := range allControlPlanes {

--- a/docker/actions/kind.go
+++ b/docker/actions/kind.go
@@ -155,7 +155,7 @@ func (m *MachineActions) DeleteControlPlane(clusterName, nodeName string) error 
 		fmt.Sprintf("name=%s$", nodeName),
 	)
 	if err != nil {
-		return nil
+		return errors.WithStack(err)
 	}
 
 	// assume it's already deleted
@@ -175,7 +175,7 @@ func (m *MachineActions) DeleteControlPlane(clusterName, nodeName string) error 
 	// Delete the infrastructure
 	log.Info("Deleting node")
 	if err := nodes.Delete(node); err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	return ConfigureLoadBalancer(clusterName)
 }


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**: This PR allows the deletion of the final/first control plane

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #109 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
