### PR TITLE
✨ Add cluster-api category

### DIFF
--- a/api/v1alpha2/dockercluster_types.go
+++ b/api/v1alpha2/dockercluster_types.go
@@ -20,9 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 const (
 	// ClusterFinalizer allows DockerClusterReconciler to clean up resources associated with DockerCluster before
 	// removing it from the apiserver.
@@ -54,9 +51,9 @@ type APIEndpoint struct {
 	Port int `json:"port"`
 }
 
+// +kubebuilder:resource:path=dockerclusters,scope=Namespaced,categories=cluster-api
 // +kubebuilder:subresource:status
 // +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
 
 // DockerCluster is the Schema for the dockerclusters API
 type DockerCluster struct {

--- a/api/v1alpha2/dockermachine_types.go
+++ b/api/v1alpha2/dockermachine_types.go
@@ -39,7 +39,7 @@ type DockerMachineStatus struct {
 	Ready bool `json:"ready"`
 }
 
-// +kubebuilder:subresource:status
+// +kubebuilder:resource:path=dockermachines,scope=Namespaced,categories=cluster-api
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
@@ -8,9 +8,11 @@ metadata:
 spec:
   group: infrastructure.cluster.x-k8s.io
   names:
+    categories:
+    - cluster-api
     kind: DockerCluster
     plural: dockerclusters
-  scope: ""
+  scope: Namespaced
   subresources:
     status: {}
   validation:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
@@ -8,9 +8,11 @@ metadata:
 spec:
   group: infrastructure.cluster.x-k8s.io
   names:
+    categories:
+    - cluster-api
     kind: DockerMachine
     plural: dockermachines
-  scope: ""
+  scope: Namespaced
   subresources:
     status: {}
   validation:


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
Similar to the recent work done in CAPA, CAPI and CABPK, this adds cluster-api categories to our cluster-api CRDs.

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
