### PR TITLE
production ready dockerfile

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,13 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.12.9 as builder
+FROM golang:1.12.9
 
 # default the go proxy
 ARG goproxy=https://proxy.golang.org
 
 # run this with docker build --build_arg $(go env GOPROXY) to override the goproxy
 ENV GOPROXY=$goproxy
+
+WORKDIR /tmp
+# install a couple of dependencies
+RUN curl -L https://dl.k8s.io/v1.14.4/kubernetes-client-linux-amd64.tar.gz | tar xvz
+RUN mv /tmp/kubernetes/client/bin/kubectl /usr/local/bin
+RUN curl https://get.docker.com | sh
 
 WORKDIR /workspace
 COPY go.mod go.mod
@@ -28,29 +34,19 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
-COPY ./ ./
+COPY cmd/ cmd/
+COPY api/ api/
+COPY controllers/ controllers/
+COPY docker docker/
+COPY third_party/ third_party/
+COPY cloudinit/ cloudinit/
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager ./cmd/manager/main.go
+# Allow containerd to restart pods by calling /restart.sh (mostly for tilt + fast dev cycles)
+# TODO: Remove this on prod and use a multi-stage build
+COPY third_party/forked/rerun-process-wrapper/start.sh .
+COPY third_party/forked/rerun-process-wrapper/restart.sh .
 
-# Use alpine:latest as minimal base image to package the manager binary and its dependencies
-FROM alpine:latest
+RUN go install -v ./cmd/manager
+RUN mv /go/bin/manager /manager
 
-# install a couple of dependencies
-WORKDIR /tmp
-RUN apk add --update \
-    curl \
-    && rm -rf /var/cache/apk/*
-
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.15.0/bin/linux/amd64/kubectl && \
-    chmod +x ./kubectl && \
-    mv ./kubectl /usr/local/bin/kubectl
-
-RUN curl -LO https://download.docker.com/linux/static/stable/x86_64/docker-19.03.1.tgz && \
-    tar zxvf docker-19.03.1.tgz --strip 1 -C /usr/bin docker/docker && \
-    rm docker-19.03.1.tgz
-
-WORKDIR /
-COPY --from=builder /workspace/manager .
-
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["./start.sh", "/manager"]


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR renames the current `Dockerfile` into `Dockerfile.dev` and adds a production-ready  `Dockerfile`

The image size is 157MB, down from the ~2GB of the dev image

**Special notes for your reviewer**:
CAPD requires some dependencies installed in the docker image, so I'm using alpine as the base image instead of distroless, but I guess this is fine for the scope of CAPD

**Release note**:
```release-note
NONE
```

/assign @chuckha @detiber @vincepri 