### PR TITLE
Support kustomize v3.1.0

### DIFF
--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - certificate.yaml
 

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
@@ -6,7 +8,7 @@ resources:
 - bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
-patches:
+#patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_dockermachines.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -14,11 +14,6 @@ namePrefix: capd-
 #commonLabels:
 #  someName: someValue
 
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in crd/kustomization.yaml
-#- ../webhook
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager
-
 patchesStrategicMerge:
 - manager_image_patch.yaml
   # Protect the /metrics endpoint by putting it behind auth.
@@ -69,7 +64,12 @@ patchesStrategicMerge:
 #    kind: Service
 #    version: v1
 #    name: webhook-service
+
 resources:
 - ../crd
 - ../rbac
 - ../manager
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in crd/kustomization.yaml
+#- ../webhook
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
+#- ../certmanager

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - manager.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
This supports kustomize v3.1.0 which is the newest release of kustomize. It includes adding the apiversion/group/kind of the Kustomization type.

**Release note**:
```release-note
Kustomize v3.1.x support
```
