### PR TITLE
Fix controlplane init

### DIFF
--- a/docker/nodes.go
+++ b/docker/nodes.go
@@ -73,6 +73,7 @@ func (n *Node) Create(cloudConfig []byte) (*nodes.Node, error) {
 			if err := actions.GetKubeConfig(cp, dest, hostAddress, hostPort); err != nil {
 				return nil, errors.Wrap(err, "failed to get kubeconfig from node")
 			}
+			return cp, nil
 		}
 		log.Info("Adding an additional control plane node")
 		return n.MachineActions.AddControlPlane(n.Cluster, n.Machine, n.Version, cloudConfig)


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently we attempt to create an additional controlplane immediately after creating the first controlplane, which results in an error reconciling the first machine and an orphaned docker container.

**Release note**:
```release-note
NONE
```
