### PR TITLE
✨ Add DockerMachine.Spec.CustomImage for customizing the container image the node runs

### DIFF
--- a/api/v1alpha2/dockermachine_types.go
+++ b/api/v1alpha2/dockermachine_types.go
@@ -31,6 +31,11 @@ type DockerMachineSpec struct {
 	// ProviderID will be the container name in ProviderID format (docker:////<containername>)
 	// +optional
 	ProviderID *string `json:"providerID,omitempty"`
+
+	// CustomImage allows customizing the container image that is used for
+	// running the machine
+	// +optional
+	CustomImage string `json:"customImage,omitempty"`
 }
 
 // DockerMachineStatus defines the observed state of DockerMachine

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
@@ -34,6 +34,10 @@ spec:
         spec:
           description: DockerMachineSpec defines the desired state of DockerMachine
           properties:
+            customImage:
+              description: CustomImage allows customizing the container image that
+                is used for running the machine
+              type: string
             providerID:
               description: ProviderID will be the container name in ProviderID format
                 (docker:////<containername>)

--- a/controllers/dockermachine_controller.go
+++ b/controllers/dockermachine_controller.go
@@ -111,7 +111,7 @@ func (r *DockerMachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 	log = log.WithValues("docker-cluster", dockerCluster.Name)
 
 	// Create a helper for managing the docker container hosting the machine.
-	externalMachine, err := docker.NewMachine(cluster.Name, machine.Name, log)
+	externalMachine, err := docker.NewMachine(cluster.Name, machine.Name, dockerMachine.Spec.CustomImage, log)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "failed to create helper for managing the externalMachine")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This enables the customization of the container image that is used for running a given DockerMachine instance. This is useful in situations where you'd like to customize the node image in some way to better suit your needs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
