### PR TITLE
🏃 Adds dockermachinetemplates to the kustomization manifest

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -6,6 +6,7 @@ kind: Kustomization
 resources:
 - bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
 - bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
+- bases/infrastructure.cluster.x-k8s.io_dockermachinetemplates.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge: []


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR adds the DockerMachineTemplate type to the kustomize yaml manifest. This allows us to use DockerMachineTemplate types after applying the `kustomize build config` output to a cluster.

