### PR TITLE
✨ Watch dockercluster

### DIFF
--- a/controllers/dockermachine_controller.go
+++ b/controllers/dockermachine_controller.go
@@ -32,7 +32,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	"sigs.k8s.io/kind/pkg/cluster/constants"
 )
@@ -54,7 +53,7 @@ type DockerMachineReconciler struct {
 // Reconcile handles DockerMachine events
 func (r *DockerMachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, rerr error) {
 	ctx := context.Background()
-	log := log.Log.WithName(machineControllerName).WithValues("docker-machine", req.NamespacedName)
+	log := r.Log.WithName(machineControllerName).WithValues("docker-machine", req.NamespacedName)
 
 	// Fetch the DockerMachine instance.
 	dockerMachine := &infrav1.DockerMachine{}
@@ -255,20 +254,32 @@ func (r *DockerMachineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // requests for reconciliation of DockerMachines.
 func (r *DockerMachineReconciler) DockerClusterToDockerMachines(o handler.MapObject) []ctrl.Request {
 	result := []ctrl.Request{}
-
 	c, ok := o.Object.(*infrav1.DockerCluster)
 	if !ok {
 		r.Log.Error(errors.Errorf("expected a DockerCluster but got a %T", o.Object), "failed to get DockerMachine for DockerCluster")
 		return nil
 	}
+	log := r.Log.WithValues("DockerCluster", c.Name, "Namespace", c.Namespace)
 
-	labels := map[string]string{clusterv1.MachineClusterLabelName: c.Name}
-	machineList := &infrav1.DockerMachineList{}
-	if err := r.Client.List(context.Background(), machineList, client.InNamespace(c.Namespace), client.MatchingLabels(labels)); err != nil {
-		r.Log.Error(err, "failed to list DockerMachines", "DockerCluster", c.Name, "Namespace", c.Namespace)
+	cluster, err := util.GetOwnerCluster(context.TODO(), r.Client, c.ObjectMeta)
+	switch {
+	case apierrors.IsNotFound(err) || cluster == nil:
+		return result
+	case err != nil:
+		log.Error(err, "failed to get owning cluster")
+		return result
+	}
+
+	labels := map[string]string{clusterv1.MachineClusterLabelName: cluster.Name}
+	machineList := &clusterv1.MachineList{}
+	if err := r.Client.List(context.TODO(), machineList, client.InNamespace(c.Namespace), client.MatchingLabels(labels)); err != nil {
+		log.Error(err, "failed to list DockerMachines")
 		return nil
 	}
 	for _, m := range machineList.Items {
+		if m.Spec.InfrastructureRef.Name == "" {
+			continue
+		}
 		name := client.ObjectKey{Namespace: m.Namespace, Name: m.Name}
 		result = append(result, ctrl.Request{NamespacedName: name})
 	}

--- a/controllers/dockermachine_controller_test.go
+++ b/controllers/dockermachine_controller_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog"
+	"k8s.io/klog/klogr"
+	infrav1 "sigs.k8s.io/cluster-api-provider-docker/api/v1alpha2"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha2"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+)
+
+func init() {
+	klog.InitFlags(nil)
+}
+
+func setupScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	if err := clusterv1.AddToScheme(s); err != nil {
+		panic(err)
+	}
+	if err := infrav1.AddToScheme(s); err != nil {
+		panic(err)
+	}
+	return s
+}
+
+func TestDockerMachineReconciler_DockerClusterToDockerMachines(t *testing.T) {
+	clusterName := "my-cluster"
+	dockerCluster := newDockerCluster(clusterName, "my-docker-cluster")
+	dockerMachine1 := newDockerMachine("my-docker-machine-0")
+	dockerMachine2 := newDockerMachine("my-docker-machine-1")
+	objects := []runtime.Object{
+		newCluster(clusterName),
+		dockerCluster,
+		newMachine(clusterName, "my-machine-0", dockerMachine1),
+		newMachine(clusterName, "my-machine-1", dockerMachine2),
+		// Intentionally omitted
+		newMachine(clusterName, "my-machine-2", nil),
+	}
+	c := fake.NewFakeClientWithScheme(setupScheme(), objects...)
+	r := DockerMachineReconciler{
+		Client: c,
+		Log:    klogr.New(),
+	}
+	mo := handler.MapObject{
+		Object: dockerCluster,
+	}
+	out := r.DockerClusterToDockerMachines(mo)
+	machineNames := make([]string, len(out))
+	for i := range out {
+		machineNames[i] = out[i].Name
+	}
+	if len(out) != 2 {
+		t.Fatal("expected 2 docker machines to reconcile but got", len(out))
+	}
+	for _, expectedName := range []string{"my-machine-0", "my-machine-1"} {
+		if !contains(machineNames, expectedName) {
+			t.Fatalf("expected %q in slice %v", expectedName, machineNames)
+		}
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, straw := range haystack {
+		if straw == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func newCluster(clusterName string) *clusterv1.Cluster {
+	return &clusterv1.Cluster{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterName,
+		},
+	}
+}
+
+func newDockerCluster(clusterName, dockerName string) *infrav1.DockerCluster {
+	return &infrav1.DockerCluster{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: dockerName,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: clusterv1.GroupVersion.String(),
+					Kind:       "Cluster",
+					Name:       clusterName,
+				},
+			},
+		},
+	}
+}
+
+func newMachine(clusterName, machineName string, dockerMachine *infrav1.DockerMachine) *clusterv1.Machine {
+	machine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: machineName,
+			Labels: map[string]string{
+				clusterv1.MachineClusterLabelName: clusterName,
+			},
+		},
+	}
+	if dockerMachine != nil {
+		machine.Spec.InfrastructureRef = v1.ObjectReference{
+			Name:       dockerMachine.Name,
+			Namespace:  dockerMachine.Namespace,
+			Kind:       dockerMachine.Kind,
+			APIVersion: dockerMachine.GroupVersionKind().GroupVersion().String(),
+		}
+	}
+	return machine
+}
+
+func newDockerMachine(name string) *infrav1.DockerMachine {
+	return &infrav1.DockerMachine{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec:   infrav1.DockerMachineSpec{},
+		Status: infrav1.DockerMachineStatus{},
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.1.0
 	github.com/pkg/errors v0.8.1
+	k8s.io/api v0.0.0-20190409021203-6e4e0e4f393b
 	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/klog v0.4.0


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR Watches DockerClusters and requeues all DockerMachines when DockerCluster updates.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #223 