### PR TITLE
🐛 Clean up manager YAML

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,8 +30,6 @@ spec:
         volumeMounts:
           - mountPath: /var/run/docker.sock
             name: dockersock
-          - mountPath: /var/lib/docker
-            name: dockerlib
         securityContext:
           privileged: true
       terminationGracePeriodSeconds: 10
@@ -39,7 +37,3 @@ spec:
         - name: dockersock
           hostPath:
             path: /var/run/docker.sock
-            type: Socket
-        - name: dockerlib
-          hostPath:
-            path: /var/lib/docker


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
For whatever reason trying to claim the file is a socket is a bad idea. Kubernetes doesn't think it's a socket but it works fine with this type removed.  In addition the docker lib is not necessary.

These changes have already happened in current release.

